### PR TITLE
feat: support apt installation of wasmrun

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,58 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  build-deb:
+    name: Build .deb package
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 'latest'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb
+
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Build .deb package
+        run: |
+          cargo deb --target ${{ matrix.target }}
+          DEB_FILE=$(find target/${{ matrix.target }}/debian -name "*.deb")
+          VERSION=${GITHUB_REF#refs/tags/}
+          cp "$DEB_FILE" "wasmrun-${VERSION}-${{ matrix.arch }}.deb"
+
+      - name: Upload .deb artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "wasmrun-*.deb"
+          draft: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@
 cargo install wasmrun
 ```
 
+### From Prebuilt Packages
+
+<details>
+<summary>DEB Package (Debian/Ubuntu/Pop! OS)</summary>
+
+![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white) ![Debian](https://img.shields.io/badge/Debian-D70A53?style=for-the-badge&logo=debian&logoColor=white) ![Pop!\_OS](https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white) ![Linux Mint](https://img.shields.io/badge/Linux%20Mint-87CF3E?style=for-the-badge&logo=Linux%20Mint&logoColor=white)
+
+Wasmrun is available as a DEB package for Debian-based systems.
+
+1. Download the latest `.deb` file from [GitHub Releases](https://github.com/anistark/wasmrun/releases)
+2. Install the package:
+
+```bash
+# Install the downloaded DEB package
+sudo apt install wasmrun_*.deb
+
+# If there are dependency issues, fix them
+sudo apt install -f
+```
+</details>
+
+Track releases on [github releases](https://github.com/anistark/wasmrun/releases) or [via release feed](https://github.com/anistark/wasmrun/releases.atom).
+
 ### From Source
 
 ```sh


### PR DESCRIPTION
Refs: #17 

This PR adds

- a GitHub Actions workflow to build and upload `.deb` packages on release.
- installation section in `README` for Debian/Ubuntu package.

*Here are the artifacts produced* - https://github.com/R0-H-1T/wasmrun/releases